### PR TITLE
カレントユーザーのテイスティングシート全件取得リソースを用意した

### DIFF
--- a/app/controllers/api/v1/tasting_sheets_controller.rb
+++ b/app/controllers/api/v1/tasting_sheets_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class Api::V1::TastingSheetsController < ApplicationController
-  def index; end
+  def index
+    render json: current_user.tasting_sheets.with_relations
+  end
 
   def create
     tasting_sheet = TastingSheetForm.new(tasting_sheet_params)
     if tasting_sheet.save
-      render json: tasting_sheet
+      render json: tasting_sheet, status: :created
     else
       render json: tasting_sheet.errors, status: :unprocessable_entity
     end

--- a/app/models/tasting_sheet.rb
+++ b/app/models/tasting_sheet.rb
@@ -10,4 +10,22 @@ class TastingSheet < ApplicationRecord
   validates :name,  presence: true
   validates :color, presence: true
   validates :time,  presence: true
+
+  scope :with_relations, lambda {
+    includes(
+      :taste,
+      :conclusion,
+      appearance: %i[
+        appearance_colors
+        appearance_impressions
+      ],
+      flavor: %i[
+        flavor_first_impressions
+        flavor_fruits
+        flavor_flowers
+        flavor_spices
+        flavor_impressions
+      ]
+    )
+  }
 end


### PR DESCRIPTION
## What
- TastingSheets#indexにcurrent_userのテイスティングシー全件を返却する処理を実装した
- N+1問題対策用のスコープをTastingSheetモデルに加えた

## Why
- フロントエンドで記録したシートを表示するため