### PR TITLE
APIで返却するTastingSheetの値にcreated_atを追加した

### DIFF
--- a/app/resources/tasting_sheet_resource.rb
+++ b/app/resources/tasting_sheet_resource.rb
@@ -3,6 +3,10 @@
 class TastingSheetResource < ApplicationResource
   attributes :id, :name, :color, :time
 
+  attribute :created_at do |resource|
+    I18n.l resource.created_at, format: :short
+  end
+
   one :appearance, resource: AppearanceResource
   one :flavor,     resource: FlavorResource
   one :taste,      resource: TasteResource

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,12 +11,14 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.time_zone = "Asia/Tokyo"
+
+    config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  time:
+    formats:
+      default: "%Y.%m.%d %H:%M:%S"
+      short: "%Y.%m.%d"


### PR DESCRIPTION
## What
- TastingSheetResourceにcreated_atの追加
- created_atのフォーマットようにロケールファイルの追加

## Why
- フロント側で作成日時を表示するため