### PR TITLE
テイスティングシートの個別情報を返却するアクションを追加した

### DIFF
--- a/app/controllers/api/v1/tasting_sheets_controller.rb
+++ b/app/controllers/api/v1/tasting_sheets_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::TastingSheetsController < ApplicationController
-  before_action :set_tasting_sheet, only: :destroy
+  before_action :set_tasting_sheet, only: %i[show destroy]
 
   def index
     render json: current_user_tasting_sheets
@@ -10,10 +10,14 @@ class Api::V1::TastingSheetsController < ApplicationController
   def create
     tasting_sheet = TastingSheetForm.new(tasting_sheet_params)
     if tasting_sheet.save
-      render json: current_user_tasting_sheets, status: :created
+      render json: serialized(current_user.tasting_sheets.latest_one), status: :created
     else
       render json: tasting_sheet.errors, status: :unprocessable_entity
     end
+  end
+
+  def show
+    render json: @tasting_sheet ? serialized(@tasting_sheet) : nil
   end
 
   def destroy
@@ -24,7 +28,7 @@ class Api::V1::TastingSheetsController < ApplicationController
   private
 
   def set_tasting_sheet
-    @tasting_sheet = current_user.tasting_sheets.find(params[:id])
+    @tasting_sheet = current_user.tasting_sheets.find_by(id: params[:id])
   end
 
   def tasting_sheet_params

--- a/app/models/tasting_sheet.rb
+++ b/app/models/tasting_sheet.rb
@@ -29,5 +29,6 @@ class TastingSheet < ApplicationRecord
       ]
     )
   }
+  scope :latest_one, -> { with_relations.last }
   scope :default, -> { with_relations.latest_order }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :health_check, only: :index
       resources :users, only: :destroy
       resources :sessions, only: :index
-      resources :tasting_sheets, only: %i(index create destroy)
+      resources :tasting_sheets, only: %i(index create destroy show)
     end
   end
 end


### PR DESCRIPTION
## What
- TastingSheets#showを追加して個別情報を返却できるようにした
- TastingSheets#createの返却値を修正した
- TastingSheetモデルに作成済みの最新レコードを返すscopeを追加した

## Why
- フロントエンド側で個別ページを実装するため