### PR TITLE
DBにテーブルを追加したので本番環境用のDBをリセットするための処理を追加した

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 rm -f ./tmp/pids/server.pid
 
+bundle exec rails db:reset RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1
 bundle exec rails db:migrate RAILS_ENV=production
 
 exec "$@"


### PR DESCRIPTION
## What
- ECS起動時にDBをリセットする処理の追加

## Why
- DBにテーブルを追加したためリセットしないとECSの起動にエラーが発生するため