### PR TITLE
ワインの新規登録処理を追加した

### DIFF
--- a/app/controllers/api/v1/wines_controller.rb
+++ b/app/controllers/api/v1/wines_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Api::V1::WinesController < ApplicationController
+  def create
+    wine = WineForm.new(wine_params)
+    if wine.save
+      render json: serialized(wine.wine_record), status: :created
+    else
+      render json: wine.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def wine_params
+    params
+      .require(:wine)
+      .permit(
+        :name,
+        :vintage,
+        :country,
+        :region,
+        :grape,
+        :alcohol_percentage,
+        :memo
+      )
+      .merge(tasting_sheet_id_params)
+  end
+
+  def tasting_sheet_id_params
+    params.permit(:tasting_sheet_id)
+  end
+
+  def serialized(records)
+    WineResource.new(records).serialize
+  end
+end

--- a/app/forms/wine_form.rb
+++ b/app/forms/wine_form.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class WineForm < ApplicationForm
+  attr_accessor :name, :vintage, :country, :region, :grape,
+                :alcohol_percentage, :memo, :tasting_sheet_id
+
+  with_options presence: true do
+    validates :name
+    validates :vintage
+    validates :country
+    validates :grape
+  end
+
+  def save
+    saved = true
+    wine = Wine.new(
+      name: name,
+      vintage: vintage,
+      country: country,
+      region: region,
+      grape: grape,
+      alcohol_percentage: alcohol_percentage,
+      memo: memo
+    )
+
+    ActiveRecord::Base.transaction do
+      saved &= wine.save
+      saved &= tasting_sheet.update(wine_id: wine.id)
+
+      raise ActiveRecord::Rollback unless saved
+    end
+    saved
+  end
+
+  def wine_record
+    tasting_sheet.wine
+  end
+
+  private
+
+  def tasting_sheet
+    TastingSheet.find(tasting_sheet_id)
+  end
+end

--- a/app/models/wine.rb
+++ b/app/models/wine.rb
@@ -7,5 +7,4 @@ class Wine < ApplicationRecord
   validates :vintage, presence: true
   validates :country, presence: true
   validates :grape,   presence: true
-  validates :memo,    presence: true
 end

--- a/app/resources/wine_resource.rb
+++ b/app/resources/wine_resource.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class WineResource < ApplicationResource
+  attributes :name, :vintage, :country, :region,
+             :grape, :alcohol_percentage, :memo
+
+  attribute :tasting_sheet_id do |resource|
+    resource.tasting_sheet.id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :users, only: :destroy
       resources :sessions, only: :index
       resources :tasting_sheets, only: %i(index create destroy show update)
+      resources :wines, only: :create
     end
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_api/issues/52

## What
- Wineモデルの追加
- Api::V1::Wines#createの追加
- WineFormの実装(Wine作成時にTastingSheetのwine_idを更新するため)
- WineResourceの実装(フロントエンドへシリアライズされたjsonを返すため)

## Why
- ワインレコードの新規作成処理を追加するため