### PR TITLE
テイスティングシートオブジェクトの返却値にワインオブジェクトを含めた && テイスティングシートが削除された場合にワインも削除するようにした

### DIFF
--- a/app/models/tasting_sheet.rb
+++ b/app/models/tasting_sheet.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TastingSheet < ApplicationRecord
+  after_destroy :destroy_wine
+
   belongs_to :user
   belongs_to :wine, optional: true
   has_one :appearance, dependent: :destroy
@@ -32,4 +34,10 @@ class TastingSheet < ApplicationRecord
   }
   scope :latest_one, -> { with_relations.last }
   scope :default, -> { with_relations.latest_order }
+
+  private
+
+  def destroy_wine
+    wine.destroy!
+  end
 end

--- a/app/models/tasting_sheet.rb
+++ b/app/models/tasting_sheet.rb
@@ -2,7 +2,7 @@
 
 class TastingSheet < ApplicationRecord
   belongs_to :user
-  belongs_to :wine
+  belongs_to :wine, optional: true
   has_one :appearance, dependent: :destroy
   has_one :flavor,     dependent: :destroy
   has_one :taste,      dependent: :destroy

--- a/app/resources/tasting_sheet_resource.rb
+++ b/app/resources/tasting_sheet_resource.rb
@@ -7,6 +7,7 @@ class TastingSheetResource < ApplicationResource
     I18n.l resource.created_at, format: :short
   end
 
+  one :wine,       resource: WineResource
   one :appearance, resource: AppearanceResource
   one :flavor,     resource: FlavorResource
   one :taste,      resource: TasteResource

--- a/app/resources/wine_resource.rb
+++ b/app/resources/wine_resource.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class WineResource < ApplicationResource
-  attributes :name, :vintage, :country, :region,
-             :grape, :alcohol_percentage, :memo
+  attributes :id, :name, :vintage, :country,
+             :region, :grape, :alcohol_percentage, :memo
 
   attribute :tasting_sheet_id do |resource|
     resource.tasting_sheet.id


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_api/issues/56

## What
- テイスティングシートオブジェクトの返却値にワインオブジェクトの情報を含めた
- ワインオブジェクトの返却値にidを追加した
- テイスティングシートオブジェクトが削除された時にワインオブジェクトも削除されるようにした
- テイスティングシートの新規作成時に外部キー、wine_idがnilであることを許容するようにした

## Why
- フロント側でテイスティングシートの情報と一緒にワインの情報を表示するため
- テイスティングシートが削除された場合、ワインも削除されるべきなため
- テイスティングシート新規作成時はワインは存在しないため