### PR TITLE
本番環境へのデプロイ時にdbがリセットされないようにした

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@ set -e
 
 rm -f ./tmp/pids/server.pid
 
-bundle exec rails db:reset RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1
 bundle exec rails db:migrate RAILS_ENV=production
 
 exec "$@"


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_api/issues/160

## What
- entrypoint.shファイルからdb:resetの実行分を削除した

## Why
- 本番環境へのデプロイ時にDBのリセットを行う必要がなくなったため