### PR TITLE
フロントエンドの実装に合わせてApi::V1::TastingSheets#updateの返却値を変更した

### DIFF
--- a/app/controllers/api/v1/wines_controller.rb
+++ b/app/controllers/api/v1/wines_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::WinesController < ApplicationController
 
   def update
     if @wine.update(wine_params)
-      render json: serialized(@wine)
+      head :no_content
     else
       render json: @wine.errors, status: :unprocessable_entity
     end


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/275

## What
- テイスティングシート名変更時の返却値を変更した

## Why
- フロント側でTastingSheetの情報を必要としなくなったため