### PR TITLE
Api::V1::TastingSheets#destroyの返却値を変更した

### DIFF
--- a/app/controllers/api/v1/tasting_sheets_controller.rb
+++ b/app/controllers/api/v1/tasting_sheets_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::TastingSheetsController < ApplicationController
 
   def destroy
     @tasting_sheet.destroy!
-    render json: current_user_tasting_sheets
+    head :no_content
   end
 
   private


### PR DESCRIPTION
## What
- Api::V1::TastingSheetsControllerのdestroyアクションの返却値を変更した

## Why
- フロントエンドでレコードを受け取る必要がなくなったため