### PR TITLE
Usersテーブルのnameカラムを削除してemailカラムを追加した

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main]
+    branches: [development]
 
 jobs:
   deploy:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,6 @@ class ApplicationController < ActionController::API
   end
 
   def find_current_user(payload)
-    @current_user = User.find_or_create_by!(uid: payload['sub'], name: payload['name'])
+    @current_user = User.find_or_create_by!(uid: payload['sub'], email: payload['email'])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@
 class User < ApplicationRecord
   has_many :tasting_sheets, dependent: :destroy
 
-  validates :uid,  presence: true, uniqueness: { scope: :name }
-  validates :name, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :email }
+  validates :email, presence: true, uniqueness: true
 end

--- a/db/migrate/20230506091920_add_email_to_users.rb
+++ b/db/migrate/20230506091920_add_email_to_users.rb
@@ -1,0 +1,6 @@
+class AddEmailToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :email, :string, null: false
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20230506092303_remove_index_uid_name.rb
+++ b/db/migrate/20230506092303_remove_index_uid_name.rb
@@ -1,0 +1,5 @@
+class RemoveIndexUidName < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, name: 'uid_name_users_index'
+  end
+end

--- a/db/migrate/20230506092630_remove_name_from_users.rb
+++ b/db/migrate/20230506092630_remove_name_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :name
+  end
+end

--- a/db/migrate/20230506092853_add_index_to_users.rb
+++ b/db/migrate/20230506092853_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, [:uid, :email], name: 'uid_email_users_index', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_124426) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_06_092853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -133,8 +133,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_124426) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", null: false
-    t.index ["uid", "name"], name: "uid_name_users_index", unique: true
+    t.string "email", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["uid", "email"], name: "uid_email_users_index", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 rm -f ./tmp/pids/server.pid
 
+bundle exec rails db:reset RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1
 bundle exec rails db:migrate RAILS_ENV=production
 
 exec "$@"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:uid) { |n| "testUid-#{n}" }
-    name           { 'tasting-sheet-user' }
+    sequence(:uid)   { |n| "testUid-#{n}" }
+    sequence(:email) { |n| "test-mail-#{n}@example.com" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,14 +6,21 @@ RSpec.describe User, type: :model do
   let(:user) { FactoryBot.build(:user) }
 
   describe 'validation' do
-    describe 'name' do
+    describe 'email' do
       example 'valid' do
         expect(user).to be_valid
       end
 
       example 'invalid with blank' do
-        user.name = ''
+        user.email = ''
         expect(user).to be_invalid
+      end
+
+      example 'invalid with existing email' do
+        user.save
+        other_user = FactoryBot.build(:user)
+        other_user.email = user.email
+        expect(other_user).to be_invalid
       end
     end
 
@@ -25,13 +32,6 @@ RSpec.describe User, type: :model do
       example 'invalid with blank uid' do
         user.uid = ''
         expect(user).to be_invalid
-      end
-
-      example 'invalid with existing uid' do
-        user.save
-        other_user = FactoryBot.build(:user)
-        other_user.uid = user.uid
-        expect(other_user).to be_invalid
       end
     end
   end


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/299

## What
- Usersテーブルの内容変更
  - nameカラムの削除
  - emailカラムの追加

## Why
- フロントエンドのサインイン方法を変更してjwtからname情報が取得できなくなったため