### PR TITLE
フロント側のサインイン方法を変更したのでユーザーの新規作成、削除処理を変更した

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class Api::V1::SessionsController < ApplicationController
-  def index
-    render json: current_user.id
-  end
-end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,29 @@
 # frozen_string_literal: true
 
 class Api::V1::UsersController < ApplicationController
+  skip_before_action :authenticate, only: :create
+
+  def index
+    render json: current_user.id
+  end
+
+  def create
+    user = User.new(user_params)
+    if user.save
+      head :no_content
+    else
+      render json: user.errors, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     current_user.destroy!
     head :no_content
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:uid, :email)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,6 @@ class ApplicationController < ActionController::API
   end
 
   def find_current_user(payload)
-    @current_user = User.find_or_create_by!(uid: payload['sub'], email: payload['email'])
+    @current_user = User.find_by!(uid: payload['sub'], email: payload['email'])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :health_check, only: :index
-      resources :users, only: :destroy
-      resources :sessions, only: :index
+      resources :users, only: %i(index create destroy)
       resources :images, only: :create
       resources :tasting_sheets, only: %i(index create destroy show update)
       resources :wines, only: %i(create destroy update)


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/299

## What
- 不要になったApi::V1::SessionsControllerの削除
- Api::V1::Users#index createの追加
  - フロントエンドでサインアップ処理が走ったタイミングでAPI側もUserレコードを作成するようにした
- ApplicationControllerの修正

## Why
- フロントエンドのサインイン方法を変更したため